### PR TITLE
Fix prefixed counting system lookup

### DIFF
--- a/src/matching.test.ts
+++ b/src/matching.test.ts
@@ -55,24 +55,40 @@ test("Finding countingSystemDetails supports legacy mixed-case map keys", () => 
   ).toStrictEqual(["fi:jyvaskyla:6714_463", "TELIA"]);
 });
 
+test("Finding countingSystemDetails falls back from vehicle-prefixed ID to raw counter ID", () => {
+  const countingSystemMap: CountingSystemMap = new Map([
+    ["0009d8066f88", ["fi:lahti:6957_155", "TELIA"]],
+  ]);
+  expect(
+    getCountingSystemDetails(countingSystemMap, "155-0009d8066f88")
+  ).toStrictEqual(["fi:lahti:6957_155", "TELIA"]);
+});
+
 test("Missing counting system diagnostics are compact and informative", () => {
   const countingSystemMap: CountingSystemMap = new Map([
     ["JL463-0009d8066cf0", ["fi:jyvaskyla:6714_463", "TELIA"]],
     ["KL006-APC", ["fi:kuopio:44517_6", "Telia"]],
+    ["0009d8066d78", ["fi:lahti:6957_475", "TELIA"]],
   ]);
   const diagnostics = getMissingCountingSystemDiagnostics(
     countingSystemMap,
     "JL475-0009d8066d78"
   );
   expect(diagnostics).toStrictEqual({
-    mapSize: 2,
+    mapSize: 3,
     normalizedCountingSystemId: "jl475-0009d8066d78",
+    lookupCandidates: [
+      "jl475-0009d8066d78",
+      "JL475-0009d8066d78",
+      "0009d8066d78",
+    ],
     hasExactKey: false,
     hasNormalizedKey: false,
+    hasSuffixKey: true,
     caseInsensitiveMatchCount: 0,
     caseInsensitiveMatchSample: [],
     samePrefixSample: ["JL463-0009d8066cf0"],
-    mapKeysSample: ["JL463-0009d8066cf0", "KL006-APC"],
+    mapKeysSample: ["JL463-0009d8066cf0", "KL006-APC", "0009d8066d78"],
   });
 });
 

--- a/src/matching.ts
+++ b/src/matching.ts
@@ -71,16 +71,44 @@ export const getCountingSystemIdFromMqttTopic = (
 ): CountingSystemId | undefined =>
   mqttTopic === undefined ? undefined : mqttTopic.split("/").at(5);
 
+const getPrefixedCountingSystemIdSuffix = (
+  countingSystemId: CountingSystemId
+): CountingSystemId | undefined => {
+  const prefixedIdParts = countingSystemId.split("-");
+  return prefixedIdParts.length > 1
+    ? prefixedIdParts.slice(1).join("-")
+    : undefined;
+};
+
+const getCountingSystemLookupCandidates = (
+  countingSystemId: CountingSystemId
+): CountingSystemId[] => {
+  const normalized = countingSystemId.toLowerCase();
+  const suffix = getPrefixedCountingSystemIdSuffix(normalized);
+
+  return Array.from(
+    new Set(
+      [normalized, countingSystemId, suffix].filter(
+        (candidate): candidate is CountingSystemId =>
+          candidate !== undefined && candidate.length > 0
+      )
+    )
+  );
+};
+
 export const getCountingSystemDetails = (
   countingSystemMap: CountingSystemMap,
   countingSystemId: CountingSystemId
 ): [UniqueVehicleId, CountingVendorName] | undefined => {
   // During rollout there may still be mixed-case keys in static map entries.
-  // Try normalized key first, then exact key for backward compatibility.
-  const normalized = countingSystemId.toLowerCase();
-  return (
-    countingSystemMap.get(normalized) ?? countingSystemMap.get(countingSystemId)
-  );
+  // Try normalized key first, then exact key for backward compatibility. Some
+  // upstream splitters prefix the raw counter ID with the vehicle short name.
+  return getCountingSystemLookupCandidates(countingSystemId)
+    .map((candidate) => countingSystemMap.get(candidate))
+    .find(
+      (details): details is [UniqueVehicleId, CountingVendorName] =>
+        details !== undefined
+    );
 };
 
 export const getMissingCountingSystemDiagnostics = (
@@ -88,6 +116,10 @@ export const getMissingCountingSystemDiagnostics = (
   countingSystemId: CountingSystemId
 ) => {
   const normalizedCountingSystemId = countingSystemId.toLowerCase();
+  const lookupCandidates = getCountingSystemLookupCandidates(countingSystemId);
+  const suffixCountingSystemId = getPrefixedCountingSystemIdSuffix(
+    normalizedCountingSystemId
+  );
   const mapKeys = Array.from(countingSystemMap.keys());
   const idFamilyPrefix = normalizedCountingSystemId.match(/^[a-z]+/)?.[0];
   const maxSamples = 8;
@@ -104,8 +136,13 @@ export const getMissingCountingSystemDiagnostics = (
   return {
     mapSize: countingSystemMap.size,
     normalizedCountingSystemId,
+    lookupCandidates,
     hasExactKey: countingSystemMap.has(countingSystemId),
     hasNormalizedKey: countingSystemMap.has(normalizedCountingSystemId),
+    hasSuffixKey:
+      suffixCountingSystemId == null
+        ? false
+        : countingSystemMap.has(suffixCountingSystemId),
     caseInsensitiveMatchCount: caseInsensitiveMatches.length,
     caseInsensitiveMatchSample: caseInsensitiveMatches,
     samePrefixSample,


### PR DESCRIPTION
Fix journey-matcher lookup for APC messages whose countingSystemId is prefixed with the vehicle short name.

Root cause: the dynamic vehicle registry map is keyed by raw counter IDs, while incoming APC messages can contain IDs like 155-0009d8066f88. The matcher only tried exact full IDs, so valid registry entries were missed and no matched APC output was produced.

Changes: add normalized/exact/suffix lookup candidates and include those candidates in missing-map diagnostics. Add regression coverage for the prefixed Lahti-style ID.

Validation: npm run check-and-build
